### PR TITLE
doc: update README.md on invalid VAT number case

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ const checkedVat = await getVatNumberInfos(vatNumber)
 }
 ```
 
+N.B: will throw if VAT number is invalid.
+
 ### How to contribute
 
 * Clone the repository `git clone git@github.com:adriantombu/vat-number.git`


### PR DESCRIPTION
We should know that it throws when VAT number is invalid.

BTW, would have been better to return `false` or `valid: false` prop in the result object.